### PR TITLE
Change util to utils

### DIFF
--- a/emailuser/admin.py
+++ b/emailuser/admin.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.contrib import admin
 from django.contrib import messages
-from django.contrib.admin.util import flatten_fieldsets
+from django.contrib.admin.utils import flatten_fieldsets
 from django.contrib.auth.forms import AdminPasswordChangeForm
 from django.db import transaction
 from django.http import Http404

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-libtech-emailuser',
-    version='0.2-2',
+    version='0.2-3',
     packages=['emailuser', 'emailuser.migrations'],
     include_package_data=True,
     license='BSD License',


### PR DESCRIPTION
Fixes XX-XXXX

```
[7931 ] 2016-03-17 16:42:50,025 WARNING  /usr/local/lib/python2.7/site-packages/django/contrib/admin/util.py:7: RemovedInDjango19Warning: The django.contrib.admin.util module has been renamed. Use django.contrib.admin.utils instead.
  "Use django.contrib.admin.utils instead.", RemovedInDjango19Warning)
```

A tag of "0.2-3" is required on this commit.
